### PR TITLE
fix_dollar_in_echo_redirection_problem_in_echo

### DIFF
--- a/build_in.c
+++ b/build_in.c
@@ -65,8 +65,8 @@ int		execute_builtin(t_varlist **head_var, t_command *cmd_node, char **ev)
 	}
 	if (ft_strcmp(cmd_node->args[0], "env") == 0)
 		return (builtin_env(ev));
-	// if (ft_strcmp(cmd_node->args[0], "exit") == 0)
-	// 	return (builtin_exit(cmd_node));
+	if (ft_strcmp(cmd_node->args[0], "exit") == 0)
+		return (builtin_exit(cmd_node));
 	if (ft_strcmp(cmd_node->args[0], "pwd") == 0)
 		return (builtin_pwd());
 	return (1);

--- a/extract_word.c
+++ b/extract_word.c
@@ -50,6 +50,12 @@ char	*get_word(t_parser *parser, int start, t_varlist **head_var)
 		}
 		printf("word after replaced is: %s\n", word);
 	}
+	if (if_dollar_sign(word) > 0)
+	{
+		tmp = word;
+		word = reg_dollar_sign(word, head_var);
+		free(tmp);
+	}
 	return (word);
 }
 

--- a/minishell.c
+++ b/minishell.c
@@ -102,7 +102,7 @@ void	print_fill_result(t_varlist **head_var, t_cmdlist **head_cmd, t_token **tok
 
 }
 
-void	execute_cmd_or_cmds(t_varlist **head_var, t_cmdlist **head_cmd, t_pipex	*pipe_data, char **ev)
+void	execute_cmd_or_cmds(t_varlist **head_var, t_cmdlist **head_cmd, t_pipex	*pipe_data)
 {
 	if (if_pipex(head_cmd) > 1)
 	{
@@ -117,31 +117,26 @@ void	execute_cmd_or_cmds(t_varlist **head_var, t_cmdlist **head_cmd, t_pipex	*pi
 			if(!get_in_out_files_fd(head_cmd, pipe_data))
 				return ;
 		}
-		execute_pipeline(head_cmd, pipe_data);
+		execute_pipeline(head_var, head_cmd, pipe_data);
 		if ((*head_cmd)->command->here_doc == 1)
 			unlink("here.txt");
 	}
 	else
 	{
 		printf("executing single commande: \n");
-		if (if_buildin((*head_cmd)->command->args[0]))
-			execute_builtin(head_var, (*head_cmd)->command, ev);
+		if ((*head_cmd)->command->here_doc == 1)
+		{
+			if (!execute_here_doc(head_cmd, pipe_data))
+				return ;
+		}
 		else
 		{
-			if ((*head_cmd)->command->here_doc == 1)
-			{
-				if (!execute_here_doc(head_cmd, pipe_data))
-					return ;
-			}
-			else
-			{
-				if(!get_in_out_files_fd(head_cmd, pipe_data))
-					return ;
-			}
-			execute_single_cmd(head_cmd, (*head_cmd)->command, pipe_data);
-			if ((*head_cmd)->command->here_doc == 1)
-				unlink("here.txt");
+			if(!get_in_out_files_fd(head_cmd, pipe_data))
+				return ;
 		}
+		execute_single_cmd(head_var, head_cmd, (*head_cmd)->command, pipe_data);
+		if ((*head_cmd)->command->here_doc == 1)
+			unlink("here.txt");
 	}
 }
 
@@ -191,7 +186,7 @@ void	minishell(char *input, t_varlist **head_var, char **envp)
 		return ;
 	}
 	init_pipe_data(pipe_data, envp);
-	execute_cmd_or_cmds(head_var, &head_cmd, pipe_data, envp);
+	execute_cmd_or_cmds(head_var, &head_cmd, pipe_data);
 	free_cmdlist(&head_cmd);
 	free_parser(parser);
 	free(pipe_data);

--- a/minishell.h
+++ b/minishell.h
@@ -145,7 +145,7 @@ int		handle_word(t_parser *p, char **args, int *argc);
 int		is_cmd_token(int type);
 int		set_error(t_parser *p);
 //pipex.c
-void	execute_pipeline(t_cmdlist **head_cmd, t_pipex *pipe_data);
+void	execute_pipeline(t_varlist **head_var, t_cmdlist **head_cmd, t_pipex *pipe_data);
 //pipex_utils.c
 int		if_pipex(t_cmdlist **head_cmd);
 t_pipex	*init_pipe_data(t_pipex *pipe_data, char **envp);
@@ -157,8 +157,8 @@ int		check_outfile_permission(t_parser *parser, char *outfile);
 int		if_buildin(char *cmd);
 int		execute_builtin(t_varlist **head_var, t_command *cmd_node, char **ev);
 //execute_cmd.c
-void	execute_cmd(t_command *cmd, char **ev);
-void	execute_single_cmd( t_cmdlist **head_cmd, t_command *cmd, t_pipex *pipe_data);
+void	execute_cmd(t_varlist **head_var, t_command *command, char **ev);
+void	execute_single_cmd(t_varlist **head_var, t_cmdlist **head_cmd, t_command *cmd, t_pipex *pipe_data);
 //execute_cmd_utils.c
 void	update_exit_status(int status);
 int		if_slash(char *str);

--- a/pipex.c
+++ b/pipex.c
@@ -1,7 +1,7 @@
 #include "minishell.h"
 #include "libft.h"
 
-void	child_process(t_cmdlist **head_cmd, t_cmdlist *cur, t_pipex *pipe_data)
+void	child_process(t_varlist **head_var, t_cmdlist **head_cmd, t_cmdlist *cur, t_pipex *pipe_data)
 {
 	if (cur == *head_cmd && pipe_data->f_fds[0] != -1)
 	{
@@ -24,11 +24,7 @@ void	child_process(t_cmdlist **head_cmd, t_cmdlist *cur, t_pipex *pipe_data)
 		close(pipe_data->pipefd[1]);
 	}
 	close(pipe_data->pipefd[0]);
-	if(if_buildin(cur->command->cmd))
-	{}
-		// execute_builtin(cur->command, pipe_data->envp);
-	else
-		execute_cmd(cur->command, pipe_data->envp);
+	execute_cmd(head_var, cur->command, pipe_data->envp);
 }
 
 void	parent_process(t_cmdlist *cur, t_pipex *pipe_data)
@@ -42,7 +38,7 @@ void	parent_process(t_cmdlist *cur, t_pipex *pipe_data)
 	}
 }
 
-void	fork_and_pid(t_cmdlist **head_cmd, t_cmdlist *cur, t_pipex *pipe_data)
+void	fork_and_pid(t_varlist **head_var, t_cmdlist **head_cmd, t_cmdlist *cur, t_pipex *pipe_data)
 {
 	pid_t		pid;
 
@@ -65,7 +61,7 @@ void	fork_and_pid(t_cmdlist **head_cmd, t_cmdlist *cur, t_pipex *pipe_data)
 	if (pid == 0)
 	{
 		signal(SIGINT, SIG_DFL);
-		child_process(head_cmd, cur, pipe_data);
+		child_process(head_var, head_cmd, cur, pipe_data);
 	}
 	else
 		parent_process(cur, pipe_data);
@@ -91,14 +87,14 @@ int	wait_child_process(void)
 	return (last_status);
 }
 
-void	execute_pipeline(t_cmdlist **head_cmd, t_pipex *pipe_data)
+void	execute_pipeline(t_varlist **head_var, t_cmdlist **head_cmd, t_pipex *pipe_data)
 {
 	t_cmdlist	*cur;
 
 	cur = *head_cmd;
 	while (cur)
 	{
-		fork_and_pid(head_cmd, cur, pipe_data);
+		fork_and_pid(head_var, head_cmd, cur, pipe_data);
 		cur = cur->next;
 	}
 	g_exit_status = wait_child_process();

--- a/var_val.c
+++ b/var_val.c
@@ -83,7 +83,6 @@ int 	init_registre_variable(t_variable *var_dt, char *input)
 	value = NULL;
 	if (if_export_variable(input))
 		var_dt->exported = 1;
-	printf("i am adding a variable and value %s, %s\n", var_dt->var, var_dt->val);
 	if (!verify_and_init_var_val(input, var_dt))
 		return (0);
 	if (!registre_var_val(input, var_dt, value))


### PR DESCRIPTION
Found a bug in the interpretation of the dollar sign. So, echo "$NAME" and echo $NAME both interpret the variable correctly, just like in the shell. I replaced the call to execute_builtin so that it now correctly interprets redirection either as a single command or as part of a pipex command sequence.